### PR TITLE
Standardize defn of weights as inverse variance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,3 +4,4 @@
 
 - Add ``copy_data`` argument in ``WPCA``. If set to False, this will prevent
   unnecessary copies of the data.
+- Use inverse variance consistently as the weight for ``WPCA`` and ``EMPCA``. Fixes issue #2.

--- a/wpca/empca.py
+++ b/wpca/empca.py
@@ -88,7 +88,7 @@ class EMPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -135,7 +135,7 @@ class EMPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -159,7 +159,7 @@ class EMPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -202,7 +202,7 @@ class EMPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -224,7 +224,7 @@ class EMPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------

--- a/wpca/empca.py
+++ b/wpca/empca.py
@@ -122,6 +122,7 @@ class EMPCA(BaseEstimator, TransformerMixin):
             XW = X_c * weights
             total_var = np.sum((XW ** 2).sum(0) / (weights ** 2).sum(0))
         self.explained_variance_ratio_ = (self.explained_variance_ / total_var)
+        self.n_iter_ = 1 # needed by sklearn.utils.estimator_checks
         return coeff
 
     def fit(self, X, y=None, weights=None):

--- a/wpca/wpca.py
+++ b/wpca/wpca.py
@@ -127,6 +127,8 @@ class WPCA(BaseEstimator, TransformerMixin):
         self.explained_variance_ = evals[::-1]
         self.explained_variance_ratio_ = evals[::-1] / covar.trace()
 
+        self.n_iter_ = 1 # needed by sklearn.utils.estimator_checks
+
     def transform(self, X, weights=None):
         """Apply dimensionality reduction on X.
 

--- a/wpca/wpca.py
+++ b/wpca/wpca.py
@@ -72,10 +72,6 @@ class WPCA(BaseEstimator, TransformerMixin):
         X, weights = check_array_with_weights(X, weights, dtype=float,
                                               copy=self.copy_data)
 
-        # Convert from inverse variance to inverse sigmas.
-        # See eqn. 7 of Delchambre 2015 and issue #2.
-        weights = np.sqrt(weights)
-
         if fit_mean:
             self.mean_ = weighted_mean(X, weights, axis=0)
 
@@ -83,6 +79,9 @@ class WPCA(BaseEstimator, TransformerMixin):
         X -= self.mean_
 
         if weights is not None:
+            # Convert from inverse variance to inverse sigmas.
+            # See eqn. 7 of Delchambre 2015 and issue #2.
+            weights = np.sqrt(weights)
             X *= weights
         else:
             weights = np.ones_like(X)

--- a/wpca/wpca.py
+++ b/wpca/wpca.py
@@ -61,12 +61,20 @@ class WPCA(BaseEstimator, TransformerMixin):
         self.copy_data = copy_data
 
     def _center_and_weight(self, X, weights, fit_mean=False):
-        """Compute centered and weighted version of X.
+        """Compute centered and weighted version of X and adjust weights.
+
+        Input weights are inverse variance and adjusted weights are
+        inverse sigmas. Will produce a RuntimeWarning if any input
+        weights are negative.
 
         If fit_mean is True, then also save the mean to self.mean_
         """
         X, weights = check_array_with_weights(X, weights, dtype=float,
                                               copy=self.copy_data)
+
+        # Convert from inverse variance to inverse sigmas.
+        # See eqn. 7 of Delchambre 2015 and issue #2.
+        weights = np.sqrt(weights)
 
         if fit_mean:
             self.mean_ = weighted_mean(X, weights, axis=0)
@@ -92,7 +100,7 @@ class WPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -141,7 +149,7 @@ class WPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -174,7 +182,7 @@ class WPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -213,7 +221,7 @@ class WPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------
@@ -235,7 +243,7 @@ class WPCA(BaseEstimator, TransformerMixin):
 
         weights: array-like, shape (n_samples, n_features)
             Non-negative weights encoding the reliability of each measurement.
-            Equivalent to the inverse of the Gaussian errorbar.
+            Equivalent to the inverse variance when errors are Gaussian.
 
         Returns
         -------


### PR DESCRIPTION
Update docstrings for both WPCA and EMPCA to change weights description from:
```
Equivalent to the inverse of the Gaussian errorbar.
```
to:
```
Equivalent to the inverse variance when errors are Gaussian.
```
(EMPCA description was wrong before).

Update WPCA to use sqrt(weights) internally via `_center_and_weight()`.

Fixes #2 and the easy part of #6.